### PR TITLE
Added list metrics fucntionality

### DIFF
--- a/tehuti.py
+++ b/tehuti.py
@@ -287,7 +287,7 @@ def main(metrics_module_name, ref_commit=None, target_commit=None,
         used.
 
     """
-    metrics = __import__(metrics_module_name).metrics
+    metrics = importlib.import_module(metrics_module_name).metrics
 
     if single_id is not None and single_id not in (metric.id() for
                                                    metric in metrics):


### PR DESCRIPTION
This PR adds a `--list` command to the command line options to allow the metrics in a metrics modules to be listed so it's simpler to get the ids of metrics you may wish to run individually. It also tidies up the case where you specify an unknown metric.
