### PR TITLE
tehuti-vis x-axis label shortening

### DIFF
--- a/tehuti-vis.py
+++ b/tehuti-vis.py
@@ -19,7 +19,7 @@ import argparse
 
 import matplotlib.pyplot as plt
 
-from tehuti import Results, sha
+from tehuti import Results, sha, shorten_sha
 
 
 # Based on (minor label tweaks and line plotting on single value input):
@@ -65,7 +65,7 @@ def plot(picked, single_id):
         labels = []
         data = []
         for commit, results in picked:
-            labels.append(_short(commit))
+            labels.append(shorten_sha(commit))
             data.append(results[key])
         ax = plt.axes()
         ax.set_title(key)

--- a/tehuti.py
+++ b/tehuti.py
@@ -106,6 +106,33 @@ def sha(name):
     return output.strip()
 
 
+def shorten_sha(sha):
+    """
+    Takes a long hex string (e.g. a git commit sha) and shortens it to
+    8 characters.
+
+    If the input value cannot be cast as a hex then the input is returned
+    unchanged.
+
+    Args:
+
+    * sha:
+        A hex string.
+
+    Returns:
+        The input shortened to 8 characters if input is a hex string, or input
+        if not.
+
+    """
+    try:
+        int(sha, 16)
+    except ValueError:
+        result = sha
+    else:
+        result = sha[:8]
+    return result
+
+
 def working_tree_id():
     try:
         id = sha('HEAD')


### PR DESCRIPTION
When visually comparing the results of metrics runs the x-axis label is set to the full SHA of the chosen git commits being compared. This PR adds a simple function that shortens the SHA to the first 8 characters, a la git, if the label is a hex string.
