### PR TITLE
Corrected pylint metric status code check

### DIFF
--- a/tehuti.py
+++ b/tehuti.py
@@ -23,6 +23,7 @@ import os
 import subprocess
 import sys
 import timeit
+import warnings
 
 
 class Metric(object):
@@ -88,7 +89,9 @@ class PylintMetric(Metric):
         pylint = subprocess.Popen(cmd + [self.module], stdout=subprocess.PIPE,
                                   stderr=subprocess.PIPE)
         output, _ = pylint.communicate()
-        if pylint.returncode == 0:
+        # Pylint error codes 1 (fatal error) and 32 (user error) indicate a
+        # failed run.
+        if pylint.returncode not in [1, 32]:
             output = output.split('\n')
             rating = [line for line in output
                       if 'code has been rated at' in line]
@@ -97,6 +100,9 @@ class PylintMetric(Metric):
             # Possibly this should raise some sort of metric-failure
             # error, or just return a failure token which can be recorded
             # in the results cache.
+            msg = 'Pylint process failed with error code {}, defaulting code '\
+                  'rating to 0.'
+            warnings.warn(msg.format(pylint.returncode))
             rating = 0
         return rating
 


### PR DESCRIPTION
This corrects the issue that was preventing the tehuti Pylint Metric from working. The problem arises because Pylint does not uniquely use `0` as the status code indicating successful execution. Instead status codes `1` & `32` indicate some form of non-recoverable error but `0` and 2<sup>n</sup> values in the range `2 <= 16` are bit-ORed so that the status code indicates what pylint errors were detected.

This is detailed at http://lists.logilab.org/pipermail/python-projects/2009-November/002068.html and in the pylint help (though note that `pylint --long-help` is required to display the status codes details).

I've also taken the opportunity to add a warning if a non-recoverable status code is encountered.